### PR TITLE
Fix vulnerabilities found by Nancy tool

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -21,7 +21,7 @@
   revision = "f65c72e2690dc4b403c8bd637baf4611cd4c069b"
 
 [[projects]]
-  digest = "1:20fe4d1ddcf154899839cbe7aafc754a76c601f77a93c4ff805a73b7d94881dd"
+  digest = "1:1a3e3cc77a6785d6bd4f16bde7daff384262ff005cc02dc6262b5743cceab08a"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -34,6 +34,7 @@
     "aws/credentials/ec2rolecreds",
     "aws/credentials/endpointcreds",
     "aws/credentials/processcreds",
+    "aws/credentials/ssocreds",
     "aws/credentials/stscreds",
     "aws/csm",
     "aws/defaults",
@@ -42,28 +43,35 @@
     "aws/request",
     "aws/session",
     "aws/signer/v4",
+    "internal/context",
+    "internal/encoding/gzip",
     "internal/ini",
     "internal/sdkio",
     "internal/sdkmath",
     "internal/sdkrand",
     "internal/sdkuri",
     "internal/shareddefaults",
+    "internal/strings",
+    "internal/sync/singleflight",
     "private/protocol",
     "private/protocol/json/jsonutil",
     "private/protocol/jsonrpc",
     "private/protocol/query",
     "private/protocol/query/queryutil",
     "private/protocol/rest",
+    "private/protocol/restjson",
     "private/protocol/xml/xmlutil",
     "service/cloudwatch",
     "service/cloudwatchlogs",
     "service/rds",
+    "service/sso",
+    "service/sso/ssoiface",
     "service/sts",
     "service/sts/stsiface",
   ]
   pruneopts = "NUT"
-  revision = "ed081a7af453411de4fdd66717d9f68bbcc3b92c"
-  version = "v1.25.45"
+  revision = "4f0bc23ad379b199b41670feae94b026a90e64cb"
+  version = "v1.44.44"
 
 [[projects]]
   digest = "1:707ebe952a8b3d00b343c01536c79c73771d100f63ec6babeaed5c79e2b8a8dd"
@@ -74,6 +82,14 @@
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:ec8ed04d28ac0f02d00f971f4ef84543c71aadf762d9876d32fcaed029fa4660"
+  name = "github.com/cespare/xxhash"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "e7a6b52374f7e2abfb8abb27249d53a1997b09a7"
+  version = "v2.1.2"
+
+[[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
@@ -82,9 +98,15 @@
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:573ca21d3669500ff845bdebee890eb7fc7f0f50c59f2132f2a0c6b03d85086a"
+  digest = "1:796f9c63c68774a89eade387a8476e45ec2b34f5649b0726983204202c3649d6"
   name = "github.com/golang/protobuf"
-  packages = ["proto"]
+  packages = [
+    "proto",
+    "ptypes",
+    "ptypes/any",
+    "ptypes/duration",
+    "ptypes/timestamp",
+  ]
   pruneopts = "NUT"
   revision = "6c65a5562fc06764971b7c5d05c76c75e84bdbf7"
   version = "v1.3.2"
@@ -113,14 +135,6 @@
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:c706e6cf1803e8cbce88ad1159c8750ec0dacbeac7c3906e615af69c0c1d6281"
-  name = "github.com/shatteredsilicon/exporter_shared"
-  packages = ["helpers"]
-  pruneopts = "NUT"
-  revision = "074d05bfecbb11bfbb09cd29fd718c9c4a1d2e64"
-  version = "v0.6.0"
-
-[[projects]]
   digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
@@ -129,7 +143,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:097cc61836050f45cbb712ae3bb45d66fba464c16b8fac09907fa3c1f753eff6"
+  digest = "1:458768c8bc0807d8e960cefd412aee419d4dea1cfb2804ddb88908c7ff922a4b"
   name = "github.com/prometheus/client_golang"
   packages = [
     "prometheus",
@@ -137,19 +151,19 @@
     "prometheus/promhttp",
   ]
   pruneopts = "NUT"
-  revision = "170205fb58decfd011f1550d4cfb737230d7ae4f"
-  version = "v1.1.0"
+  revision = "989baa30fe956631907493ccee1f8e7708660d96"
+  version = "v1.11.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:982be0b5396e16a663697899ce69cc7b1e71ddcae4153af157578d4dc9bc3f88"
+  digest = "1:0db23933b8052702d980a3f029149b3f175f7c0eea0cff85b175017d0f2722c0"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
   pruneopts = "NUT"
-  revision = "d1d2010b5beead3fa1c5f271a5cf626e40b3ad6e"
+  revision = "7bc5445566f0fe75b15de23e6b93886e982d7bf9"
+  version = "v0.2.0"
 
 [[projects]]
-  digest = "1:22b0ad1d8dbb7f1961d53f45e69743b2f92a0e076901401b9fed78c0eb058879"
+  digest = "1:917f4ec9cae4bc19d8806f782c066a51651136f8ac59ddb76db2c88dfe2c4001"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
@@ -159,8 +173,8 @@
     "version",
   ]
   pruneopts = "NUT"
-  revision = "287d3e634a1e550c9e463dd7e5a75a422c614505"
-  version = "v0.7.0"
+  revision = "0ec6a33fff8b8a6950b82f03c4bfabaf61ac4813"
+  version = "v0.26.0"
 
 [[projects]]
   digest = "1:a4b063a766f50cdadc1fce12053e3bde8599f1f8b7621d7e293cd2fc86543a44"
@@ -173,6 +187,14 @@
   pruneopts = "NUT"
   revision = "6d489fc7f1d9cd890a250f3ea3431b1744b9623f"
   version = "v0.0.8"
+
+[[projects]]
+  digest = "1:c706e6cf1803e8cbce88ad1159c8750ec0dacbeac7c3906e615af69c0c1d6281"
+  name = "github.com/shatteredsilicon/exporter_shared"
+  packages = ["helpers"]
+  pruneopts = "NUT"
+  revision = "074d05bfecbb11bfbb09cd29fd718c9c4a1d2e64"
+  version = "v0.6.0"
 
 [[projects]]
   digest = "1:f4aaa07a6c33f2b354726d0571acbc8ca118837c75709f6353203ae1a3f8eeab"
@@ -232,11 +254,12 @@
     "github.com/aws/aws-sdk-go/service/cloudwatch",
     "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
     "github.com/aws/aws-sdk-go/service/rds",
-    "github.com/shatteredsilicon/exporter_shared/helpers",
+    "github.com/cespare/xxhash",
     "github.com/prometheus/client_golang/prometheus",
     "github.com/prometheus/client_golang/prometheus/promhttp",
     "github.com/prometheus/common/log",
     "github.com/prometheus/common/version",
+    "github.com/shatteredsilicon/exporter_shared/helpers",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",
     "gopkg.in/alecthomas/kingpin.v2",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,4 +1,30 @@
+required = ['github.com/cespare/xxhash']
+
+ignored = [
+  'github.com/cespare/xxhash/v2'
+]
+
 [prune]
   go-tests = true
   non-go = true
   unused-packages = true
+
+[[constraint]]
+  name = 'github.com/cespare/xxhash'
+  version = "^2.1.2"
+
+[[override]]
+  name = 'github.com/aws/aws-sdk-go'
+  version = "^v1.44.44"
+
+[[override]]
+  name = 'github.com/prometheus/client_golang'
+  version = "~v1.11.1"
+
+[[override]]
+  name = 'github.com/prometheus/client_model'
+  version = "~v0.2.0"
+
+[[override]]
+  name = 'github.com/prometheus/common'
+  version = "~v0.26.0"

--- a/rds_exporter.spec
+++ b/rds_exporter.spec
@@ -39,6 +39,8 @@ ln -s $(pwd) src/%{provider_prefix}
 
 %build
 export GOPATH=$(pwd)
+mkdir -p vendor/github.com/cespare/xxhash/v2
+find vendor/github.com/cespare/xxhash  ! -path '*/v2' -mindepth 1 -maxdepth 1 -exec mv {} vendor/github.com/cespare/xxhash/v2 \;
 GO111MODULE=off go build -ldflags "${LDFLAGS:-} -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')" -a -v -x %{provider_prefix}
 
 


### PR DESCRIPTION
Following vulnerabilities are found by [Nancy](https://github.com/sonatype-nexus-community/nancy) tool

![CleanShot 2022-06-29 at 19 32 40@2x](https://user-images.githubusercontent.com/61085039/176426934-ba689091-6523-4253-bc7b-c9211911267d.png)

[Vulnerability 1](https://ossindex.sonatype.org/vulnerability/sonatype-2020-1759)
[Vulnerability 2](https://ossindex.sonatype.org/vulnerability/CVE-2020-8911?component-type=golang&component-name=github.com%2Faws%2Faws-sdk-go&utm_source=nancy-client&utm_medium=integration&utm_content=1.0.37)
[Vulnerability 3](https://ossindex.sonatype.org/vulnerability/CVE-2020-8912?component-type=golang&component-name=github.com%2Faws%2Faws-sdk-go&utm_source=nancy-client&utm_medium=integration&utm_content=1.0.37)
[Vulnerability 4](https://ossindex.sonatype.org/vulnerability/CVE-2022-21698?component-type=golang&component-name=github.com%2Fprometheus%2Fclient_golang&utm_source=nancy-client&utm_medium=integration&utm_content=1.0.37)